### PR TITLE
sated: add food blinking duration configurability

### DIFF
--- a/Sated/SatedPlugin.cs
+++ b/Sated/SatedPlugin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 Crystal Ferrai
+// Copyright 2023 Crystal Ferrai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -158,49 +158,49 @@ namespace Sated
                 TranspilerState state = TranspilerState.Searching;
 
                 foreach (CodeInstruction instruction in instructions)
-				{
-					switch (state)
-					{
-						case TranspilerState.Searching:
+                {
+                    switch (state)
+                    {
+                        case TranspilerState.Searching:
                             if (instruction.opcode == OpCodes.Ldloca_S)
-							{
+                            {
                                 state = TranspilerState.Checking1;
-							}
+                            }
                             yield return instruction;
-							break;
+                            break;
                         case TranspilerState.Checking1:
                             if (instruction.opcode == OpCodes.Call)
                             {
                                 state = TranspilerState.Checking2;
                             }
                             else
-							{
+                            {
                                 state = TranspilerState.Searching;
-							}
+                            }
                             yield return instruction;
                             break;
                         case TranspilerState.Checking2:
                             if (instruction.opcode == OpCodes.Stloc_1)
-							{
+                            {
                                 state = TranspilerState.ReplacingHp;
-							}
+                            }
                             else
-							{
+                            {
                                 state = TranspilerState.Searching;
-							}
+                            }
                             yield return instruction;
                             break;
                         case TranspilerState.ReplacingHp:
                             if (instruction.opcode == OpCodes.Ldfld)
-							{
+                            {
                                 yield return new CodeInstruction(OpCodes.Call, typeof(Player_Patches).GetMethod(nameof(GetHp), BindingFlags.NonPublic | BindingFlags.Static));
                                 state = TranspilerState.ReplacingStamina;
-							}
+                            }
                             else
-							{
+                            {
                                 yield return instruction;
-							}
-							break;
+                            }
+                            break;
                         case TranspilerState.ReplacingStamina:
                             if (instruction.opcode == OpCodes.Ldfld)
                             {
@@ -225,13 +225,13 @@ namespace Sated
                             break;
                         case TranspilerState.Finishing:
                             yield return instruction;
-							break;
-					}
-				}
+                            break;
+                    }
+                }
             }
 
             private static float GetHp(Player.Food food)
-			{
+            {
                 return (1.0f - Mathf.Pow(GetTime(food), HealthCurveExponent.Value)) * food.m_item.m_shared.m_food;
             }
 
@@ -246,7 +246,7 @@ namespace Sated
             }
 
             private static float GetTime(Player.Food food)
-			{
+            {
                 return 1.0f - food.m_time / food.m_item.m_shared.m_foodBurnTime;
             }
         }

--- a/Sated/package/README.md
+++ b/Sated/package/README.md
@@ -2,7 +2,10 @@ Health and stamina from food follows the curve ``y=1-x^8`` instead of the vanill
 
 Run the game once with the mod enabled to generate the config. See config for details on what each option does.
 
-Tip: The exponent of the curve is configurable. To visualize the food curve and see how different exponents look, enter the above formula into a graphing calculator such as [this one](https://www.desmos.com/calculator) and change the ``8`` to whatever number you want to see.
+Tips:
+
+- The exponent of the curve is configurable. To visualize the food curve and see how different exponents look, enter the above formula into a graphing calculator such as [this one](https://www.desmos.com/calculator) and change the ``8`` to whatever number you want to see.
+- The food blinking duration is configurable. In vanilla, food starts blinking after half of its duration, at which point another food may be consumed to replace it. If you tweaked the curve so that food lasts longer, you may want to reduce the blinking duration. To visualize when food starts blinking w.r.t. to your chosen food curve, enter the formula ``x>(100-50)/100`` on the same calculator above and adjust ``50`` to your liking.
 
 This mod is client only and does not need to be installed on dedicated servers. For the best experience, all clients should use the same configuration.
 
@@ -15,6 +18,10 @@ This mod is designed to install and run via [r2modman](https://thunderstore.io/p
 3. Run the game once, then close it and edit the generated cfg file in ``[GameDirectory]\Bepinex\config`` if you want to customize anything.
 
 ## Changelog
+
+Unreleased
+
+* Added config option to adjust food blinking duration.
 
 1.1.11
 


### PR DESCRIPTION
Since Sated is mostly used to make food last longer, the vanilla food blinking duration (half of total food duration) might be too long for aggressive curves, so we add the possibility for users to configure the blinking duration to their liking.

Additionally, noticed some space <-> tabs indentation discrepancy, fixed by normalizing to spaces.